### PR TITLE
Small improvements.

### DIFF
--- a/UIViewController+Debugging.h
+++ b/UIViewController+Debugging.h
@@ -9,5 +9,5 @@
 #import <UIKit/UIKit.h>
 
 @interface UIViewController (Debugging)
-- (void)showDebugger;
+- (void)toggleDebugger;
 @end

--- a/UIViewController+Debugging.m
+++ b/UIViewController+Debugging.m
@@ -9,7 +9,7 @@
 #import "UIViewController+Debugging.h"
 
 @implementation UIViewController (Debugging)
-- (void)showDebugger
+- (void)toggleDebugger
 {
 #ifdef DEBUG
 #pragma clang diagnostic push

--- a/UIViewController+Debugging.m
+++ b/UIViewController+Debugging.m
@@ -15,7 +15,10 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
     id debugClass = NSClassFromString(@"UIDebuggingInformationOverlay");
-    [debugClass performSelector:NSSelectorFromString(@"prepareDebuggingOverlay")];
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [debugClass performSelector:NSSelectorFromString(@"prepareDebuggingOverlay")];
+    });
     
     id debugOverlayInstance = [debugClass performSelector:NSSelectorFromString(@"overlay")];
     [debugOverlayInstance performSelector:NSSelectorFromString(@"toggleVisibility")];


### PR DESCRIPTION
This PR does a couple small things.

- Makes it so that the prepare method is only invoked once per run of the app.
- Renames the method to from `show` to `toggle` to match the underlying method call.